### PR TITLE
Add extend package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generate magnet-uri from torrent file",
   "repository": "git://github.com/apsdehal/torrent-to-magnet.git",
   "dependencies": {
+    "extend": "^3.0.0",
     "parse-torrent": "~1.0.0",
     "request": "~2.16.2"
   },


### PR DESCRIPTION
Hi,

This is a fix for the missing "extend" dependencie in the `package.json` file.
